### PR TITLE
feat Oauth2 scheme for session based security between frontend and backend

### DIFF
--- a/lib/schemes/oauth2Session.js
+++ b/lib/schemes/oauth2Session.js
@@ -1,0 +1,114 @@
+import nanoid from "nanoid";
+import { encodeQuery } from "../utilities.js";
+const isHttps = process.server ? require("is-https") : null;
+
+const DEFAULTS = {
+	response_type: "code",
+	access_type: "offline"
+};
+
+export default class Oauth2SessionScheme {
+	constructor(auth, options) {
+		this.$auth = auth;
+		this.req = auth.ctx.req;
+		this.name = options._name;
+
+		this.options = Object.assign({}, DEFAULTS, options);
+	}
+
+	get _scope() {
+		return Array.isArray(this.options.scope)
+			? this.options.scope.join(" ")
+			: this.options.scope;
+	}
+
+	get _redirectURI() {
+		const url = this.options.redirect_uri;
+
+		if (url) {
+			return url;
+		}
+
+		if (process.server && this.req) {
+			const protocol = "http" + (isHttps(this.req) ? "s" : "") + "://";
+
+			return protocol + this.req.headers.host + this.options.redirect;
+		}
+
+		if (process.client) {
+			return window.location.origin + this.options.redirect;
+		}
+	}
+
+	async mounted() {
+		// Handle callbacks on page load
+		const redirected = await this._handleCallback();
+		if (!redirected) {
+			return this.$auth.fetchUserOnce();
+		}
+	}
+
+	login({ params, state } = {}) {
+		const opts = {
+			response_type: this.options.response_type,
+			access_type: this.options.access_type,
+			client_id: this.options.client_id,
+			redirect_uri: this._redirectURI,
+			scope: this._scope,
+			// Note: The primary reason for using the state parameter is to mitigate CSRF attacks.
+			// https://auth0.com/docs/protocols/oauth2/oauth-state
+			state: state || nanoid(),
+			...params
+		};
+
+		this.$auth.$storage.setUniversal(this.name + ".state", opts.state);
+
+		const url = this.options.authorization_endpoint + "?" + encodeQuery(opts);
+
+		window.location = url;
+	}
+
+	async _handleCallback(uri) {
+		// Handle callback only for redirect callback route
+		if (this.$auth.ctx.route.path !== this.options.redirect) {
+			return;
+		}
+		// Callback flow is not supported in server side
+		if (process.server) {
+			return;
+		}
+
+		const parsedQuery = Object.assign({}, this.$auth.ctx.route.query);
+
+		// Validate state
+		const state = this.$auth.$storage.getUniversal(this.name + ".state");
+		this.$auth.$storage.setUniversal(this.name + ".state", null);
+
+		if (state && parsedQuery.state !== state) {
+			return;
+		}
+
+		// -- Send code to backend --
+		if (this.options.response_type === "code" && parsedQuery.code) {
+			await this.$auth.request({
+				method: "post",
+				url: this.options.access_token_endpoint,
+				baseURL: process.server ? undefined : false,
+				withCredentials: true,
+				data: encodeQuery({
+					code: parsedQuery.code,
+					response_type: this.options.response_type,
+					client_id: this.options.client_id,
+					redirect_uri: this._redirectURI
+				})
+			});
+		}
+		// Set local strategy
+		this.$auth.setStrategy("local");
+
+		// Redirect to home
+		this.$auth.redirect("home", true);
+
+		return true; // True means a redirect happened
+	}
+}


### PR DESCRIPTION
## Problem description
Website using a cookie/session-based security between frontend and backend (nuxt.config.js -> local strategy, tokenRequired: false, tokenType: false). 

### Task
The task is to integrate social networks sign in leaving existing cookie/session-based security.

### Solution
Adding a button on a page. 

eg `<button @click.native="$auth.loginWith('facebook_session')">Facebook Sign in</button>`

It initiating Oauth2 login and consent screens. Flow as in the image below, except step 6. In case of successful authentication backend returning session cookie Instead of JWT token. Oauth2SessionScheme receiving session cookie and changing social_session strategy to local strategy. The user is logged in and further communication is secured with session-cookie.

![OAuth2](http://i.imgur.com/BQPXKyT.png)  

#### Example nuxt.config.js configuration
Here using scheme locally ->  _scheme: "~/utils/auth/oauth2Session.js",

```JS
	auth: {
		watchLoggedIn: false,
		strategies: {
			local: {
				endpoints: {
					login: {
						url: "/v1/users/login",
						method: "post"
					},
					user: {
						url: "/v1/users/me",
						method: "get"
					},
					logout: {
						url: "/v1/users/logout",
						method: "get"
					}
				},
				tokenRequired: false,
				tokenType: false
			},
			google_session: {
				_scheme: "~/utils/auth/oauth2Session.js",
				authorization_endpoint: "https://accounts.google.com/o/oauth2/auth",
				client_id:
					"23232323-dsfdf.apps.googleusercontent.com",
				redirect: "/oauth",
				access_token_endpoint: `${process.env.API_URL}/v1/google/login`,
				scope: ["openid", "profile", "email"]
				// redirect_uri: "http://localhost:4001/oauth", // Disable in case redirect enabled
			},
			facebook_session: {
				_scheme: "~/utils/auth/oauth2Session.js",
				authorization_endpoint: "https://www.facebook.com/v5.0/dialog/oauth",
				client_id: "3434343434",
				redirect: "/oauth",
				access_token_endpoint: `${process.env.API_URL}/v1/facebook/login`,
				scope: ["public_profile", "email"]
				// redirect_uri: "http://localhost:4001/oauth", // Disable in case redirect enabled
			}
		}
	},
```